### PR TITLE
Adds PTR records for `_services._dns-sd._udp.local` on every published service.

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -31,7 +31,7 @@ function Service (opts) {
 }
 
 Service.prototype._records = function () {
-  var records = [ rrPtr(this), rrSrv(this), rrTxt(this) ]
+  var records = [ rrPtrServices(this), rrPtr(this), rrSrv(this), rrTxt(this) ]
 
   if (this.subtypes) {
     for (var subtypeIndex = 0; subtypeIndex < this.subtypes.length; subtypeIndex += 1) {
@@ -53,6 +53,15 @@ Service.prototype._records = function () {
   })
 
   return records
+}
+
+function rrPtrServices (service) {
+  return {
+    name: '_services._dns-sd._udp.local',
+    type: 'PTR',
+    ttl: 28800,
+    data: service.type + TLD
+  }
 }
 
 function rrPtr (service, subtypeIndex) {

--- a/test/service.js
+++ b/test/service.js
@@ -74,6 +74,7 @@ test('txt', function (t) {
 test('_records() - minimal', function (t) {
   var s = new Service({ name: 'Foo Bar', type: 'http', protocol: 'tcp', port: 3000 })
   t.deepEqual(s._records(), [
+    { data: '_http._tcp.local', name: '_services._dns-sd._udp.local', ttl: 28800, type: 'PTR' },
     { data: s.fqdn, name: '_http._tcp.local', ttl: 28800, type: 'PTR' },
     { data: { port: 3000, target: os.hostname() }, name: s.fqdn, ttl: 120, type: 'SRV' },
     { data: new Buffer('00', 'hex'), name: s.fqdn, ttl: 4500, type: 'TXT' }
@@ -84,6 +85,7 @@ test('_records() - minimal', function (t) {
 test('_records() - everything', function (t) {
   var s = new Service({ name: 'Foo Bar', type: 'http', protocol: 'tcp', port: 3000, host: 'example.com', txt: { foo: 'bar' } })
   t.deepEqual(s._records(), [
+    { data: '_http._tcp.local', name: '_services._dns-sd._udp.local', ttl: 28800, type: 'PTR' },
     { data: s.fqdn, name: '_http._tcp.local', ttl: 28800, type: 'PTR' },
     { data: { port: 3000, target: 'example.com' }, name: s.fqdn, ttl: 120, type: 'SRV' },
     { data: new Buffer('07666f6f3d626172', 'hex'), name: s.fqdn, ttl: 4500, type: 'TXT' }


### PR DESCRIPTION
This allows service type enumeration to occur (allowing a node to determine all services published by the host).

See the [DNS-SD RFC](https://tools.ietf.org/html/rfc6763#section-9) for more information.
